### PR TITLE
Fixes a bug that enables dry-run in all run

### DIFF
--- a/src/lib.ts
+++ b/src/lib.ts
@@ -170,7 +170,7 @@ export async function run() {
     }
 
     core.info("dry_run: " + dryRun + " (" + typeof (dryRun) + ")");
-    if (dryRun) {
+    if (dryRun === "true) {
       core.info("Dry run: not performing tag action.");
       return;
     }


### PR DESCRIPTION
As core.getInput evaluates to string all but empty string did evaluate to true at Line 174.